### PR TITLE
升级支持fis资源定位

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,11 +49,18 @@ function addDeriveFile(file, type, content, required = false) {
 }
 
 module.exports = function (content, file, options = DEFAULT_OPTIONS) {
+    // 在atom文件先执行一次js编译，目的是将 __uri 等资源定位先做了，否则atom无法编译文件
+    content = fis.compile.partial(content, file, {
+        ext: 'js',
+        isJsLike: true
+    });
+    file.setContent(content);
+    // 继续走之后的 js parser 流程。
 
     if (Buffer.isBuffer(content)) {
         content = content.toString('utf-8');
     }
-
+    // console.log('content', file.fullname, content);
     let result = atom.compile({
         content: content,
         strip: false,

--- a/index.js
+++ b/index.js
@@ -54,7 +54,13 @@ module.exports = function (content, file, options = DEFAULT_OPTIONS) {
         ext: 'js',
         isJsLike: true
     });
+    // 处理诸如： <img src="../img/apply-for-toast.png" alt="apply-job">
+    content = fis.compile.partial(content, file, {
+        ext: 'html',
+        isHtmlLike: true
+    });
     file.setContent(content);
+
     // 继续走之后的 js parser 流程。
 
     if (Buffer.isBuffer(content)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fis3-parser-atom",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -18,6 +18,8 @@
   },
   "homepage": "https://github.com/jinzhubaofu/fis3-parser-atom#readme",
   "dependencies": {
+    "less": "^2.7.2",
+    "less-plugin-autoprefix": "^1.5.1",
     "vip-server-renderer": "^1.0.20"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fis3-parser-atom",
+  "name": "fis3-parser-atom-tmp",
   "version": "1.0.1",
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fis3-parser-atom-tmp",
+  "name": "fis3-parser-atom",
   "version": "1.0.1",
   "description": "",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "dependencies": {
     "less": "^2.7.2",
     "less-plugin-autoprefix": "^1.5.1",
-    "vip-server-renderer": "^1.0.20"
+    "vip-server-renderer": "1.0.39"
   }
 }


### PR DESCRIPTION
1. 支持fis资源定位，atom文件使用相对路径引用资源文件
2. 把vip-server-render定死在1.0.39， 招聘后端是1.0.39，用更高版本编译版本会不一致，后续再改进
